### PR TITLE
bug: fix missing whitespace

### DIFF
--- a/bsp-howto/console.rst
+++ b/bsp-howto/console.rst
@@ -17,7 +17,7 @@ processing in addition to the "normal" standard input and output device
 functions required of a console.
 
 The serial driver may be called as the consequence of a C Library call such as
-``printf`` or ``scanf`` or directly via the``read`` or ``write`` system calls.
+``printf`` or ``scanf`` or directly via the ``read`` or ``write`` system calls.
 There are two main functioning modes:
 
 - console: formatted input/output, with special characters (end of line,


### PR DESCRIPTION
As seen in https://docs.rtems.org/releases/rtems-docs-4.11.1/bsp-howto/console.html shows as 
"directly via the``read`` or write system calls."